### PR TITLE
Package info

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = function(options) {
   return es.map(function (file, cb) {
  	var html = file.contents.toString();
 		html2jade.convertHtml(html, options, function (err, jade) { 
-	    console.log(jade);
 	    file.contents = new Buffer( jade );
 	    file.path = gutil.replaceExtension(file.path, '.jade');
 	    cb(null,file);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hemanth/gulp-hogan"
+    "url": "https://github.com/hemanth/gulp-html2jade"
   },
   "keywords": [
     "jade",
@@ -19,9 +19,9 @@
   "author": "Hemanth.HM",
   "license": "BSD-2-Clause",
   "bugs": {
-    "url": "https://github.com/hemanth/gulp-hogan/issues"
+    "url": "https://github.com/hemanth/gulp-html2jade/issues"
   },
-  "homepage": "https://github.com/hemanth/gulp-hogan",
+  "homepage": "https://github.com/hemanth/gulp-html2jade",
   "dependencies": {
     "gulp-util": "~2.2.5",
     "event-stream": "~3.0.20",


### PR DESCRIPTION
Hi there,

I did some cleanup.
The first commit, is to avoid confusion in the npm registry since, it points to your gulp-hogan repo.
The second commit, is to avoid printing the generated .jade files in the console when running a gulp task.

Thanks.
